### PR TITLE
assign custom name for 2D interpolation eval handler

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# v0.6.3
+
+- fixes an issue that might arise if 2D interpolation is used together
+  with multithreading where the Nim compiler gets confused about GC
+  unsafety (#23)

--- a/src/numericalnim/interpolate.nim
+++ b/src/numericalnim/interpolate.nim
@@ -22,18 +22,20 @@ type
     dx*, dy*: float
     xLim*, yLim*: tuple[lower: float, upper: float]
     eval_handler*: Eval2DHandler[T]
+  EvalUnstructured2DHandler*[T, U] = proc (self: InterpolatorUnstructured2DType[T, U], x, y: float): U {.nimcall.}
   InterpolatorUnstructured2DType*[T: SomeFloat, U] = ref object
     values*: Tensor[T]
     points*: Tensor[U]
     dt*: DelaunayTriangulation
     z*, gradX*, gradY*: Table[(T, T), U]
     boundPoints*: array[4, Vector2]
-    eval_handler*: proc (self: InterpolatorUnstructured2DType[T, U], x, y: float): U {.nimcall.}
+    eval_handler*: EvalUnstructured2DHandler[T, U]
+  Eval3DHandler*[T] = proc (self: Interpolator3DType[T], x, y, z: float): T {.nimcall.}
   Interpolator3DType*[T] = ref object
     f*: Tensor[T] # 3D tensor
     dx*, dy*, dz*: float
     xLim*, yLim*, zLim*: tuple[lower: float, upper: float]
-    eval_handler*: proc (self: Interpolator3DType[T], x, y, z: float): T {.nimcall.}
+    eval_handler*: Eval3DHandler[T]
 
 
 proc findInterval*(list: openArray[float], x: float): int {.inline.} =

--- a/src/numericalnim/interpolate.nim
+++ b/src/numericalnim/interpolate.nim
@@ -15,12 +15,13 @@ type
     eval_handler*: EvalHandler[T]
     deriveval_handler*: EvalHandler[T]
   EvalHandler*[T] = proc(self: InterpolatorType[T], x: float): T {.nimcall.}
+  Eval2DHandler*[T] = proc (self: Interpolator2DType[T], x, y: float): T {.nimcall.}
   Interpolator2DType*[T] = ref object
     z*, xGrad*, yGrad*, xyGrad*: Tensor[T] # 2D tensor
     alphaCache*: Table[(int, int), Tensor[T]]
     dx*, dy*: float
     xLim*, yLim*: tuple[lower: float, upper: float]
-    eval_handler*: proc (self: Interpolator2DType[T], x, y: float): T {.nimcall.}
+    eval_handler*: Eval2DHandler[T]
   InterpolatorUnstructured2DType*[T: SomeFloat, U] = ref object
     values*: Tensor[T]
     points*: Tensor[U]


### PR DESCRIPTION
Yes, this was really the reason.

For other people: the problem I encountered was that in a multithreaded program that already used 1D linear interpolation, adding 2D bilinear caused GC unsafe errors at CT.

The basic idea of the problem causing code:

```nim
type
  Foo = ref object
    interp: Interpolator2DType[float]
  Bar = object
    val: float
proc dostuff(b: var Bar, f: Foo) =
  b.val = f.interp.eval(1.0)
proc wrap(bs: ptr UncheckedArray[Bar], bufLen: int, f: Foo) =
  parallelFor idx in 0 ..< bufLen:
    captures: {bs, f}
    bs[idx].dostuff(f)
proc main =
  var bs = newSeq[Bar](1_000_000)
  let f = Foo(interp: ...) # init an interpolator
  wrap(bs[0].addr, bs.len, f)
```