### PR TITLE
make `NumContext` (and related types) a double generic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    
+
   schedule:
-    # Run every month the 20th when the clock is 13:00 UTC 
+    # Run every month the 20th when the clock is 13:00 UTC
     - cron: '0 13 20 * *'
 
   # Allows you to run this workflow manually from the Actions tab
@@ -35,5 +35,5 @@ jobs:
         with:
           nim-version: ${{ matrix.nim }}
       - run: nimble install -Y
+      - run: nimble testDeps -Y
       - run: nimble test
-

--- a/numericalnim.nimble
+++ b/numericalnim.nimble
@@ -16,7 +16,7 @@ task testDeps, "Install external dependencies required for tests":
   exec "nimble install https://github.com/SciNim/Measuremancer.git"
 
 task test, "Run all tests":
-  exec "nim c -r --experimental:unicodeOperators tests/test_integrate.nim"
+  exec "nim c -r tests/test_integrate.nim"
   exec "nim c -r tests/test_interpolate.nim"
   exec "nim c -r tests/test_ode.nim"
   exec "nim c -r tests/test_optimize.nim"

--- a/numericalnim.nimble
+++ b/numericalnim.nimble
@@ -9,3 +9,16 @@ srcDir = "src"
 requires "nim >= 1.0"
 requires "arraymancer >= 0.5.0"
 requires "https://github.com/HugoGranstrom/cdt#head"
+
+task testDeps, "Install external dependencies required for tests":
+  ## installs all required external dependencies that are only used
+  ## for tests
+  exec "nimble install https://github.com/SciNim/Measuremancer.git"
+
+task test, "Run all tests":
+  exec "nim c -r --experimental:unicodeOperators tests/test_integrate.nim"
+  exec "nim c -r tests/test_interpolate.nim"
+  exec "nim c -r tests/test_ode.nim"
+  exec "nim c -r tests/test_optimize.nim"
+  exec "nim c -r tests/test_utils.nim"
+  exec "nim c -r tests/test_vector.nim"

--- a/src/numericalnim/common/commonTypes.nim
+++ b/src/numericalnim/common/commonTypes.nim
@@ -1,45 +1,45 @@
 import tables
 
 type
-  NumContext*[T] = ref object
-    fValues*: Table[string, float]
+  NumContext*[T; U] = ref object
+    fValues*: Table[string, U]
     tValues*: Table[string, T]
 
-  ODEProc*[T] = proc(t: float, y: T, ctx: NumContext[T]): T
+  ODEProc*[T; U] = proc(t: U, y: T, ctx: NumContext[T, U]): T
 
-  NumContextProc*[T] = proc(x: float, ctx: NumContext[T]): T
+  NumContextProc*[T; U] = proc(x: U, ctx: NumContext[T, U]): T
 
-  InterpolatorProc*[T] = proc(x: float): T 
+  InterpolatorProc*[T] = proc(x: float): T
 
-proc newNumContext*[T](fValues: Table[string, float] = initTable[string, float](), tValues: Table[string, T] = initTable[string, T]()): NumContext[T] =
-  NumContext[T](fValues: fValues, tValues: tValues)
+proc newNumContext*[T; U](fValues: Table[string, U] = initTable[string, U](), tValues: Table[string, T] = initTable[string, T]()): NumContext[T, U] =
+  NumContext[T, U](fValues: fValues, tValues: tValues)
 
-proc `[]`*[T](ctx: NumContext[T], key: string): T =
+proc `[]`*[T; U](ctx: NumContext[T, U], key: string): T =
   ctx.tValues[key]
 
-proc `[]`*[T](ctx: NumContext[T], key: enum): T =
+proc `[]`*[T; U](ctx: NumContext[T, U], key: enum): T =
   ctx.tValues[$key]
 
-proc `[]=`*[T](ctx: NumContext[T], key: string, val: T) =
+proc `[]=`*[T; U](ctx: NumContext[T, U], key: string, val: T) =
   ctx.tValues[key] = val
 
-proc `[]=`*[T](ctx: NumContext[T], key: enum, val: T) =
+proc `[]=`*[T; U](ctx: NumContext[T, U], key: enum, val: T) =
   ctx.tValues[$key] = val
 
-proc getF*[T](ctx: NumContext[T], key: string): float =
+proc getF*[T; U](ctx: NumContext[T, U], key: string): U =
   ctx.fValues[key]
 
-proc setF*[T](ctx: NumContext[T], key: string, val: float) =
+proc setF*[T; U](ctx: NumContext[T, U], key: string, val: U) =
   ctx.fValues[key] = val
 
-proc getF*[T](ctx: NumContext[T], key: enum): float =
+proc getF*[T; U](ctx: NumContext[T, U], key: enum): U =
   ctx.fValues[$key]
 
-proc setF*[T](ctx: NumContext[T], key: enum, val: float) =
+proc setF*[T; U](ctx: NumContext[T, U], key: enum, val: U) =
   ctx.fValues[$key] = val
 
 when isMainModule:
-  var a = newNumContext[int]()
+  var a = newNumContext[int, float]()
   a["hej"] = 1
   a["då"] = 2
   echo a[]
@@ -50,7 +50,7 @@ when isMainModule:
       val2
       val3
 
-  var b = newNumContext[float]()
+  var b = newNumContext[float, float]()
   b[val1] = 1.0
   b[val2] = 2.0
   b[val3] = 3.0

--- a/src/numericalnim/common/commonTypes.nim
+++ b/src/numericalnim/common/commonTypes.nim
@@ -14,10 +14,6 @@ type
 proc newNumContext*[T; U](fValues: Table[string, U] = initTable[string, U](), tValues: Table[string, T] = initTable[string, T]()): NumContext[T, U] =
   NumContext[T, U](fValues: fValues, tValues: tValues)
 
-proc newNumContext*[T](fValues: Table[string, float] = initTable[string, float](),
-                       tValues: Table[string, T] = initTable[string, T]()): NumContext[T, float] =
-  NumContext[T, float](fValues: fValues, tValues: tValues)
-
 proc `[]`*[T; U](ctx: NumContext[T, U], key: string): T =
   ctx.tValues[key]
 

--- a/src/numericalnim/common/commonTypes.nim
+++ b/src/numericalnim/common/commonTypes.nim
@@ -14,6 +14,10 @@ type
 proc newNumContext*[T; U](fValues: Table[string, U] = initTable[string, U](), tValues: Table[string, T] = initTable[string, T]()): NumContext[T, U] =
   NumContext[T, U](fValues: fValues, tValues: tValues)
 
+proc newNumContext*[T](fValues: Table[string, float] = initTable[string, float](),
+                       tValues: Table[string, T] = initTable[string, T]()): NumContext[T, float] =
+  NumContext[T, float](fValues: fValues, tValues: tValues)
+
 proc `[]`*[T; U](ctx: NumContext[T, U], key: string): T =
   ctx.tValues[key]
 

--- a/src/numericalnim/integrate.nim
+++ b/src/numericalnim/integrate.nim
@@ -750,7 +750,8 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
     const highOrderNodes = [-0.9956571630258080807355, -0.9301574913557082260012, -0.7808177265864168970637, -0.562757134668604683339, -0.294392862701460198131,
                             0.0, 0.2943928627014601981311, 0.562757134668604683339, 0.7808177265864168970637, 0.9301574913557082260012, 0.9956571630258080807355] # nodes for high order
 
-    var intervals = IntervalList[T, U](list: newSeqOfCap[IntervalType[T, U]](maxintervals))
+    type V = typeof(calcError(default(T), default(T)))
+    var intervals = IntervalList[T, U, V](list: newSeqOfCap[IntervalType[T, U, V]](maxintervals))
 
     let (initHigh, initLow) = calcGaussKronrod(f, points_transformed[0], points_transformed[1], ctx, lowOrderWeights, lowOrderNodes, highOrderCommonWeights, highOrderWeights, highOrderNodes)
     let zero = initHigh - initHigh

--- a/src/numericalnim/integrate.nim
+++ b/src/numericalnim/integrate.nim
@@ -669,8 +669,8 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
                 points_transformed[i] = 1 / (1 + x)
             else:
                 points_transformed[i] = 1 / (1 - x)
-        xStart = 0.0
-        xEnd = 1.0
+        xStart = 0.0 + default(U)
+        xEnd = 1.0 + default(U)
         points_transformed.add(xStart)
         points_transformed.add(xEnd)
     elif xStart == Inf and xEnd == -Inf: # Done
@@ -681,8 +681,8 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
                 points_transformed[i] = 1 / (1 + x)
             else:
                 points_transformed[i] = 1 / (1 - x)
-        xStart = 0.0
-        xEnd = 1.0
+        xStart = 0.0 + default(U)
+        xEnd = 1.0 + default(U)
         points_transformed.add(xStart)
         points_transformed.add(xEnd)
     elif xStart == -Inf: # Done
@@ -690,8 +690,8 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
         for i in 0 .. points_transformed.high:
             let x = points_transformed[i]
             points_transformed[i] = 1 / (1 + xEnd_in - x)
-        xStart = 0.0
-        xEnd = 1.0
+        xStart = 0.0 + default(U)
+        xEnd = 1.0 + default(U)
         points_transformed.add(xStart)
         points_transformed.add(xEnd)
     elif xStart == Inf: # Done
@@ -699,8 +699,8 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
         for i in 0 .. points_transformed.high:
             let x = points_transformed[i]
             points_transformed[i] = 1 / (1 + x - xEnd_in)
-        xStart = 0.0
-        xEnd = 1.0
+        xStart = 0.0 + default(U)
+        xEnd = 1.0 + default(U)
         points_transformed.add(xStart)
         points_transformed.add(xEnd)
     elif xEnd == Inf: # Done
@@ -708,8 +708,8 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
         for i in 0 .. points_transformed.high:
             let x = points_transformed[i]
             points_transformed[i] = 1 / (1.0 + x - xStart_in)#xStart_in + (1-x) / x # we must inverse, this is x(t) not t(x)
-        xStart = 0.0
-        xEnd = 1.0
+        xStart = 0.0 + default(U)
+        xEnd = 1.0 + default(U)
         points_transformed.add(xStart)
         points_transformed.add(xEnd)
     elif xEnd == -Inf: # Done
@@ -717,8 +717,8 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
         for i in 0 .. points_transformed.high:
             let x = points_transformed[i]
             points_transformed[i] = 1 / (1 + xStart_in - x)
-        xStart = 0.0
-        xEnd = 1.0
+        xStart = 0.0 + default(U)
+        xEnd = 1.0 + default(U)
         points_transformed.add(xStart)
         points_transformed.add(xEnd)
     else:

--- a/src/numericalnim/integrate.nim
+++ b/src/numericalnim/integrate.nim
@@ -9,7 +9,7 @@ from ./interpolate import InterpolatorType, newHermiteSpline
 type
     IntervalType[T] = object
         lower, upper: float # integration bounds
-        error: float # estimated error for current interval
+        error: T # estimated error for current interval
         value: T # estimated value for integral over current interval
     IntervalList[T] = object
         list: seq[IntervalType[T]] # contains all the intervals sorted from smallest to largest error
@@ -761,7 +761,7 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
     let initInterval = IntervalType[T](lower: points_transformed[0], upper: points_transformed[1], error: initError, value: initHigh)
     intervals.insert(initInterval)
     var totalValue: T = initHigh
-    var totalError: float = initError
+    var totalError: T = initError
     for i in 1 .. points_transformed.high - 1:
         let (initHigh, initLow) = calcGaussKronrod(f, points_transformed[i], points_transformed[i+1], ctx, lowOrderWeights, lowOrderNodes, highOrderCommonWeights, highOrderWeights, highOrderNodes)
         let initError = calcError(initHigh - initLow, zero)
@@ -770,7 +770,8 @@ template adaptiveGaussImpl(): untyped {.dirty.} =
         totalValue += initHigh
         totalError += initError
     var currentInterval: IntervalType[T]
-    var middle, error: float
+    var middle: float
+    var error: T
     var highValue, lowValue: T
 
     while totalError > tol and intervals.list.len < maxintervals:

--- a/src/numericalnim/interpolate.nim
+++ b/src/numericalnim/interpolate.nim
@@ -256,8 +256,8 @@ proc eval*[T](spline: InterpolatorType[T], x: openArray[float]): seq[T] =
 proc toProc*[T](spline: InterpolatorType[T]): InterpolatorProc[T] =
   result = proc(x: float): T = eval(spline, x)
 
-converter toNumContextProc*[T](spline: InterpolatorType[T]): NumContextProc[T] =
-  result = proc(x: float, ctx: NumContext[T]): T = eval(spline, x)
+converter toNumContextProc*[T](spline: InterpolatorType[T]): NumContextProc[T, float] =
+  result = proc(x: float, ctx: NumContext[T, float]): T = eval(spline, x)
 
 proc derivEval*[T](spline: InterpolatorType[T], x: openArray[float]): seq[T] =
   result = newSeq[T](x.len)
@@ -267,8 +267,8 @@ proc derivEval*[T](spline: InterpolatorType[T], x: openArray[float]): seq[T] =
 proc toDerivProc*[T](spline: InterpolatorType[T]): InterpolatorProc[T] =
   result = proc(x: float): T = derivEval(spline, x)
 
-proc toDerivNumContextProc*[T](spline: InterpolatorType[T]): NumContextProc[T] =
-  result = proc(x: float, ctx: NumContext[T]): T = derivEval(spline, x)
+proc toDerivNumContextProc*[T](spline: InterpolatorType[T]): NumContextProc[T, float] =
+  result = proc(x: float, ctx: NumContext[T, float]): T = derivEval(spline, x)
 
 
 ##############################################
@@ -518,7 +518,7 @@ proc newBarycentric2D*[T: SomeFloat, U](points: Tensor[T], values: Tensor[U]): I
     Vector2(x: min(x)-0.1, y: max(y)+0.1),
     Vector2(x: min(x)-0.1, y: min(y)-0.1),
     Vector2(x: max(x)+0.1, y: min(y)-0.1),
-    Vector2(x: max(x)+0.1, y: max(y)+0.1)             
+    Vector2(x: max(x)+0.1, y: max(y)+0.1)
   ]
   for i in 0 .. x.shape[0]-1:
     let coord = (x[i], y[i])
@@ -577,7 +577,7 @@ proc eval_trilinear*[T](self: Interpolator3DType[T], x, y, z: float): T {.nimcal
   let oneMinusY = 1 - y
   let c0 = c00 * oneMinusY + c10 * y
   let c1 = c01 * oneMinusY + c11 * y
-  result = c0 * (1 - z) + c1 * z 
+  result = c0 * (1 - z) + c1 * z
 
 proc newTrilinearSpline*[T](f: Tensor[T], xlim, ylim, zlim: (float, float)): Interpolator3DType[T] =
   ## Returns a trilinear spline for regularly gridded data.

--- a/src/numericalnim/ode.nim
+++ b/src/numericalnim/ode.nim
@@ -13,10 +13,10 @@ type
         relTol*: float
         scaleMax*: float
         scaleMin*: float
-    
-    ODEProc*[T] = proc(t: float, y: T, ctx: NumContext[T]): T
 
-    IntegratorProc*[T] = proc(f: ODEProc[T], t: float, y, FSAL: T, dt: float, options: ODEoptions, ctx: NumContext[T]): (T, T, float, float)
+    ODEProc*[T] = proc(t: float, y: T, ctx: NumContext[T, float]): T
+
+    IntegratorProc*[T] = proc(f: ODEProc[T], t: float, y, FSAL: T, dt: float, options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float)
 
 const fixedODE* = @["heun2", "ralston2", "kutta3", "heun3", "ralston3", "ssprk3", "ralston4", "kutta4", "rk4"]
 const adaptiveODE* = @["rk21", "bs32", "dopri54", "tsit54", "vern65"]
@@ -86,7 +86,7 @@ const DEFAULT_ODEoptions = newODEoptions()
 
 
 proc HEUN2_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let k1 = f(t, y, ctx)
     let k2 = f(t + dt, y + dt * k1, ctx)
@@ -94,7 +94,7 @@ proc HEUN2_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     return (yNew, yNew, dt, 0.0)
 
 proc RALSTON2_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let k1 = f(t, y, ctx)
     let k2 = f(t + 2/3 * dt, y + 2/3 * dt * k1, ctx)
@@ -102,7 +102,7 @@ proc RALSTON2_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     return (yNew, yNew, dt, 0.0)
 
 proc KUTTA3_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let k1 = f(t, y, ctx)
     let k2 = f(t + 0.5 * dt, y + 0.5 * dt * k1, ctx)
@@ -111,7 +111,7 @@ proc KUTTA3_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     return (yNew, yNew, dt, 0.0)
 
 proc HEUN3_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let k1 = f(t, y, ctx)
     let k2 = f(t + 1/3 * dt, y + 1/3 * dt * k1, ctx)
@@ -120,7 +120,7 @@ proc HEUN3_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     return (yNew, yNew, dt, 0.0)
 
 proc RALSTON3_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let k1 = f(t, y, ctx)
     let k2 = f(t + 1/2 * dt, y + 1/2 * dt * k1, ctx)
@@ -129,7 +129,7 @@ proc RALSTON3_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     return (yNew, yNew, dt, 0.0)
 
 proc SSPRK3_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let k1 = f(t, y, ctx)
     let k2 = f(t + dt, y + dt * k1, ctx)
@@ -139,7 +139,7 @@ proc SSPRK3_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
 
 
 proc RALSTON4_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let k1 = f(t, y, ctx)
     let k2 = f(t + 0.4 * dt, y + 0.4 * dt * k1, ctx)
@@ -149,7 +149,7 @@ proc RALSTON4_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     return (yNew, yNew, dt, 0.0)
 
 proc KUTTA4_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let k1 = f(t, y, ctx)
     let k2 = f(t + 1/3 * dt, y + 1/3 * dt * k1, ctx)
@@ -159,7 +159,7 @@ proc KUTTA4_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     return (yNew, yNew, dt, 0.0)
 
 proc RK4_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-                 options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+                 options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using RK4. Only for internal use.
     var k1, k2, k3, k4: T
     k1 = f(t, y, ctx)
@@ -170,7 +170,7 @@ proc RK4_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     return (yNew, yNew, dt, 0.0)
 
 proc RK21_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let absTol = options.absTol
     let relTol = options.relTol
@@ -184,14 +184,14 @@ proc RK21_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     commonAdaptiveMethodCode(yNew, error_y, order=2):
         k1 = f(t, y, ctx)
         k2 = f(t + dt, y + dt * k1, ctx)
-        
+
         yNew = y + dt * 0.5 * (k1 + k2)
         yLow = y + dt * k1
         let error_y = yNew - yLow
     result = (yNew, yNew, dt, error)
 
 proc BS32_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-    options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+    options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using Heun. Only for internal use.
     let absTol = options.absTol
     let relTol = options.relTol
@@ -208,7 +208,7 @@ proc BS32_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
         k3 = f(t + 0.75 * dt, y + 0.75 * dt * k2, ctx)
         yNew = y + dt * (2/9 * k1 + 1/3 * k2 + 4/9 * k3)
         k4 = f(t + dt, yNew, ctx)
-        
+
         yLow = y + dt * (7/24 * k1 + 1/4 * k2 + 1/3 * k3 + 1/8 * k4)
         let error_y = yNew - yLow
         # error = calcError(yNew, yLow)
@@ -216,7 +216,7 @@ proc BS32_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
 
 
 proc DOPRI54_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-                     options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+                     options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using DOPRI54. Only for internal use.
     const
         c2 = 1.0/5.0
@@ -286,7 +286,7 @@ proc DOPRI54_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
     result = (yNew, k7, dt, error)
 
 proc TSIT54_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-                     options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+                     options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using TSIT54. Only for internal use.
     const
         c2 = 0.161
@@ -353,10 +353,10 @@ proc TSIT54_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
         let error_y = dt * (bHat1 * k1 + bHat2 * k2 + bHat3 * k3 + bHat4 * k4 + bHat5 * k5 + bHat6 * k6 + bHat7 * k7)
         # error = calcError(y, yLow)
     result = (yNew, k7, dt, error)
-    
+
 
 proc VERN65_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
-                     options: ODEoptions, ctx: NumContext[T]): (T, T, float, float) =
+                     options: ODEoptions, ctx: NumContext[T, float]): (T, T, float, float) =
     ## Take a single timestep using DOPRI54. Only for internal use.
     const
         c2 = 0.06
@@ -452,7 +452,7 @@ proc VERN65_step[T](f: ODEProc[T], t: float, y, FSAL: T, dt: float,
 proc ODESolver[T](f: ODEProc[T], y0: T, tspan: openArray[float],
                   options: ODEoptions = DEFAULT_ODEoptions,
                   integrator: IntegratorProc[T],
-                  useFSAL = false, order: float, adaptive = false, ctx: NumContext[T]): (seq[float], seq[T]) =
+                  useFSAL = false, order: float, adaptive = false, ctx: NumContext[T, float]): (seq[float], seq[T]) =
     ## Handles the ODE solving. Only for internal use.
     let t0 = options.tStart
     var t = t0
@@ -523,7 +523,7 @@ proc ODESolver[T](f: ODEProc[T], y0: T, tspan: openArray[float],
         yPositive.add(y)
 
     if 0 < tNegative.len:
-        let g = proc(t: float, y: T, ctx: NumContext[T]): T = -f(-t, y, ctx)
+        let g = proc(t: float, y: T, ctx: NumContext[T, float]): T = -f(-t, y, ctx)
         FSAL = g(-t0, y0.clone(), ctx)
         dt = dtInit
         lastIter = (t: -t0, y: y0.clone(), dy: FSAL)
@@ -568,7 +568,7 @@ proc ODESolver[T](f: ODEProc[T], y0: T, tspan: openArray[float],
 
 
 proc solveODE*[T](f: ODEProc[T], y0: T, tspan: openArray[float],
-                  options: ODEoptions = DEFAULT_ODEoptions, ctx: NumContext[T] = nil,
+                  options: ODEoptions = DEFAULT_ODEoptions, ctx: NumContext[T, float] = nil,
                   integrator="dopri54"): (seq[float], seq[T]) =
     ## Solve an ODE initial value problem.
     ##
@@ -577,14 +577,14 @@ proc solveODE*[T](f: ODEProc[T], y0: T, tspan: openArray[float],
     ##   - y0: Initial value.
     ##   - tspan: Seq of t values that y will be returned at.
     ##   - options: ODEoptions object with ODE parameters.
-    ##   - ctx: A context variable that can be accessed and modified in `f`. It is a ref type so IT IS MUTABLE. It can be used to save extra information during the solving for example, or to pass in big Tensors. 
+    ##   - ctx: A context variable that can be accessed and modified in `f`. It is a ref type so IT IS MUTABLE. It can be used to save extra information during the solving for example, or to pass in big Tensors.
     ##   - integrator: String with the integrator to use. Choices: "dopri54", "tsit54", "vern65", "rk4", "rk21", "bs32", "heun2", "ralston2", "kutta3", "heun3", "ralston3", "ssprk3", "ralston4", "kutta4"
     ##
     ## Returns:
     ##   - A tuple containing a seq of t-values and a seq of y-values (t, y).
     var ctx = ctx
     if ctx.isNil:
-        ctx = newNumContext[T]()
+        ctx = newNumContext[T, float]()
     case integrator.toLower():
         of "dopri54":
             return ODESolver(f, y0, tspan.sorted(), options, DOPRI54_step[T],

--- a/src/numericalnim/utils.nim
+++ b/src/numericalnim/utils.nim
@@ -256,11 +256,11 @@ proc `^`*[float](v: Vector[float], power: float): Vector[float] {.inline.} =
   for i in 0 .. v.components.high:
     newComponents[i] = pow(v[i], power)
   result = newVector(newComponents)
- 
+
 
 proc clone*[T](x: T): T {.inline.} = x
-proc mean_squared_error*[T](y_true, y: T): float {.inline.} = abs(y_true - y)
-proc calcError*[T](y_true, y: T): float {.inline.} = mean_squared_error(y_true, y)
+proc mean_squared_error*[T](y_true, y: T): T {.inline.} = abs(y_true - y)
+proc calcError*[T](y_true, y: T): T {.inline.} = mean_squared_error(y_true, y)
 
 
 proc hermiteSpline*[T](x, x1, x2: float, y1, y2, dy1, dy2: T): T {.inline.}=

--- a/src/numericalnim/utils.nim
+++ b/src/numericalnim/utils.nim
@@ -216,7 +216,7 @@ proc abs*[T](v1: Vector[T]): Vector[T] {.inline.} =
 
 proc norm*(v1: Vector, p: int = 2): float64 {.inline.} =
   ## Calculate various norms of our Vector class
-  
+
   # we have to make a case for p = 0 to avoid division by zero, may as well flesh them all out
   case p:
     of 0:
@@ -312,7 +312,7 @@ proc delete*[T](s: var seq[T], idx: seq[int]) =
   let indices = idx.sorted(Descending)
   for i in indices:
     s.delete(i)
-  
+
 
 proc getIndexTable*[T](x: openArray[T]): Table[T, seq[int]] =
   for i in 0 .. x.high:
@@ -345,7 +345,7 @@ proc removeDuplicates*[Tx, Ty](x: seq[Tx], y: seq[seq[Ty]]): tuple[x: seq[Tx], y
     for i in dups: # loop over all duplicated indices for this set of duplicates
       for iy in 0 .. y.high: # loop over all ys and check if they are pure or impure duplicates
         if y[iy][i] != ys[iy]:
-          raise newException(ValueError, &"impure y-duplicates was found: {ys[iy]} at index {dups[0]} and {y[iy][i]} at index {i}") 
+          raise newException(ValueError, &"impure y-duplicates was found: {ys[iy]} at index {dups[0]} and {y[iy][i]} at index {i}")
   # Now collect all indices to delete
   var idxDelete: seq[int]
   for dups in duplicates:
@@ -381,7 +381,7 @@ proc sortDataset*[Tx, Ty](x: seq[Tx], y: seq[seq[Ty]], sortOrder: SortOrder = As
 proc sortDataset*[Tx, Ty](x: seq[Tx], y: seq[Ty], sortOrder: SortOrder = Ascending): tuple[x: seq[Tx], y: seq[Ty]] =
   let sortedDataset = sortDataset(x, @[y], sortOrder)
   result.x = sortedDataset.x
-  result.y = sortedDataset.y[0] 
+  result.y = sortedDataset.y[0]
 
 proc sortAndTrimDataset*[Tx, Ty](x: seq[Tx], y: seq[seq[Ty]], sortOrder: SortOrder = Ascending): tuple[x: seq[Tx], y: seq[seq[Ty]]] =
   let (xSorted, ySorted) = sortDataset(x, y, sortOrder)
@@ -397,7 +397,7 @@ proc sortDataset*[T](X: openArray[float], Y: openArray[T]): seq[(float, T)] {.in
     raise newException(ValueError, "X and Y must have the same length")
   result = zip(X, Y)
   result.sort() # sort with respect to x
-  
+
 
 proc meshgridFlat*[T](x, y: Tensor[T]): (Tensor[T], Tensor[T]) =
   ## Returns two flat (rank 1) tensors with the grid coordinates specified by `x` and `y`.

--- a/src/numericalnim/utils.nim
+++ b/src/numericalnim/utils.nim
@@ -259,9 +259,8 @@ proc `^`*[float](v: Vector[float], power: float): Vector[float] {.inline.} =
 
 
 proc clone*[T](x: T): T {.inline.} = x
-proc mean_squared_error*[T](y_true, y: T): T {.inline.} = abs(y_true - y)
-proc calcError*[T](y_true, y: T): T {.inline.} = mean_squared_error(y_true, y)
-
+proc mean_squared_error*[T](y_true, y: T): auto {.inline.} = abs(y_true - y)
+proc calcError*[T](y_true, y: T): auto {.inline.} = mean_squared_error(y_true, y)
 
 proc hermiteSpline*[T](x, x1, x2: float, y1, y2, dy1, dy2: T): T {.inline.}=
   let t = (x - x1)/(x2 - x1)

--- a/tests/test_integrate.nim
+++ b/tests/test_integrate.nim
@@ -20,6 +20,13 @@ let X = linspace(xStart, xEnd, 17)
 let Y = map(X, proc(x: float): float = f(x, optional))
 let cumY = map(X, proc(x: float): float = optional["a"] * sin(x))
 
+test "`newNumContext` with single generic arg":
+  ## just tests whether one can still construct a num context without both
+  ## generic arguments. Meaning to fall back to `float`
+  let ctx = newNumContext[float]()
+  let res = newNumContext[float, float]()
+  check typeof(ctx) is typeof(res)
+
 test "trapz func, N = 10":
     let value = trapz(f, xStart, xEnd, N = 10, ctx = optional)
     check isClose(value, correct, tol = 1e-1)

--- a/tests/test_integrate.nim
+++ b/tests/test_integrate.nim
@@ -20,13 +20,6 @@ let X = linspace(xStart, xEnd, 17)
 let Y = map(X, proc(x: float): float = f(x, optional))
 let cumY = map(X, proc(x: float): float = optional["a"] * sin(x))
 
-test "`newNumContext` with single generic arg":
-  ## just tests whether one can still construct a num context without both
-  ## generic arguments. Meaning to fall back to `float`
-  let ctx = newNumContext[float]()
-  let res = newNumContext[float, float]()
-  check typeof(ctx) is typeof(res)
-
 test "trapz func, N = 10":
     let value = trapz(f, xStart, xEnd, N = 10, ctx = optional)
     check isClose(value, correct, tol = 1e-1)

--- a/tests/test_integrate.nim
+++ b/tests/test_integrate.nim
@@ -2,16 +2,16 @@ import unittest, math, sequtils
 import arraymancer
 import numericalnim
 
-proc f(x: float, ctx: NumContext[float]): float = ctx["a"] * cos(x)
-proc fVector(x: float, ctx: NumContext[Vector[float]]): Vector[float] = cos(x) * ctx["a"]
-proc fTensor(x: float, ctx: NumContext[Tensor[float]]): Tensor[float] = @[ctx.getF("a") * cos(x), ctx.getF("a") * cos(x), ctx.getF("a") * cos(x)].toTensor()
+proc f(x: float, ctx: NumContext[float, float]): float = ctx["a"] * cos(x)
+proc fVector(x: float, ctx: NumContext[Vector[float], float]): Vector[float] = cos(x) * ctx["a"]
+proc fTensor(x: float, ctx: NumContext[Tensor[float], float]): Tensor[float] = @[ctx.getF("a") * cos(x), ctx.getF("a") * cos(x), ctx.getF("a") * cos(x)].toTensor()
 let xStart = 0.0
 let xEnd = 3.0/2.0*PI
-let optional = newNumContext[float]()
+let optional = newNumContext[float, float]()
 optional["a"] = 2.0
-let optionalVector = newNumContext[Vector[float]]()
+let optionalVector = newNumContext[Vector[float], float]()
 optionalVector["a"] = newVector([2.0, 2.0, 2.0])
-let optionalTensor = newNumContext[Tensor[float]]()
+let optionalTensor = newNumContext[Tensor[float], float]()
 optionalTensor.setF("a", 2.0)
 let correct = optional["a"] * sin(xEnd)
 let correctVector = newVector([optional["a"] * sin(xEnd), optional["a"] * sin(xEnd), optional["a"] * sin(xEnd)])
@@ -158,7 +158,7 @@ test "gaussQuad func n=13":
 test "gaussQuad func n=14":
     let value = gaussQuad(f, xStart, xEnd, nPoints=14, N=1, ctx =optional)
     check isClose(value, correct, tol=1e-9)
-        
+
 test "gaussQuad func n=15":
     let value = gaussQuad(f, xStart, xEnd, nPoints=15, N=1, ctx =optional)
     check isClose(value, correct, tol=1e-10)
@@ -278,7 +278,7 @@ test "gaussQuad Vector n=13":
 test "gaussQuad Vector n=14":
     let value = gaussQuad(fVector, xStart, xEnd, nPoints=14, N=1, ctx =optionalVector)
     check isClose(value, correctVector, tol=1e-9)
-        
+
 test "gaussQuad Vector n=15":
     let value = gaussQuad(fVector, xStart, xEnd, nPoints=15, N=1, ctx =optionalVector)
     check isClose(value, correctVector, tol=1e-10)
@@ -394,7 +394,7 @@ test "gaussQuad Tensor n=13":
 test "gaussQuad Tensor n=14":
     let value = gaussQuad(fTensor, xStart, xEnd, nPoints=14, N=1, ctx =optionalTensor)
     check isClose(value, correctTensor, tol=1e-9)
-        
+
 test "gaussQuad Tensor n=15":
     let value = gaussQuad(fTensor, xStart, xEnd, nPoints=15, N=1, ctx =optionalTensor)
     check isClose(value, correctTensor, tol=1e-10)
@@ -404,7 +404,7 @@ test "gaussQuad Tensor n=16":
     check isClose(value, correctTensor, tol=1e-10)
 
 test "gaussQuad Tensor n=17":
-    let value = gaussQuad(fTensor, xStart, xEnd, nPoints=17, N=1, ctx =optionalTensor)    
+    let value = gaussQuad(fTensor, xStart, xEnd, nPoints=17, N=1, ctx =optionalTensor)
     check isClose(value, correctTensor, tol=1e-11)
 
 test "gaussQuad Tensor n=18":

--- a/tests/test_ode.nim
+++ b/tests/test_ode.nim
@@ -2,9 +2,9 @@ import unittest, math, sequtils
 import arraymancer
 import numericalnim
 
-proc f(x: float, y: float, ctx: NumContext[float]): float = -0.1 * y
-proc fVector(x: float, y: Vector[float], ctx: NumContext[Vector[float]]): Vector[float] = -0.1 * y
-proc fTensor(x: float, y: Tensor[float], ctx: NumContext[Tensor[float]]): Tensor[float] = -0.1 * y
+proc f(x: float, y: float, ctx: NumContext[float, float]): float = -0.1 * y
+proc fVector(x: float, y: Vector[float], ctx: NumContext[Vector[float], float]): Vector[float] = -0.1 * y
+proc fTensor(x: float, y: Tensor[float], ctx: NumContext[Tensor[float], float]): Tensor[float] = -0.1 * y
 proc correct_answer(x: float): float = exp(-0.1*x)
 let oo = newODEoptions(relTol=1e-8, dt=1e-6)
 let ooVector = newODEoptions(relTol=1e-8, dt=1e-2)
@@ -183,7 +183,7 @@ test "Tsit54 Vector, dt = 1e-2":
     check t == tspan
     for i, val in y:
         check isClose(val, correctYVector[i], tol=1e-8)
-        
+
 test "Vern65 Vector, default":
     let (t, y) = solveODE(fVector, y0Vector, tspan, integrator="vern65")
     check t == tspan


### PR DESCRIPTION
This replaces some occurrences of `float` in the (at least
Gauss-Kronrod) integration routine and in the `IntervalType`.

I've tested all of the following procedures and they all manage to
integrate `Measurement[float]` now.

- simpson
- adaptiveGauss
- trapz
- adaptiveSimpson
- romberg
- gaussQuad
- adaptiveGaussLocal

Sample code (not a test due to external dependency)

```nim
import numericalnim, measuremancer

proc foo[T](x: float, ctx: NumContext[T]): T =
  result = exp(x / ctx["a"])

let a = 4.71 ± 0.01
type T = typeof(a)
var ctx = newNumContext[T]()
ctx["a"] = a
echo simpson[T](foo, 1, 7, ctx = ctx).pretty(5)
echo trapz[T](foo, 1, 7, ctx = ctx).pretty(5)
echo adaptiveSimpson[T](foo, 1, 7, ctx = ctx).pretty(5)
echo romberg[T](foo, 1, 7, ctx = ctx).pretty(5)
echo gaussQuad[T](foo, 1, 7, ctx = ctx).pretty(5)
echo adaptiveGaussLocal[T](foo, 1, 7, ctx = ctx).pretty(5)
echo adaptiveGauss[T](foo, 1, 7, ctx = ctx).pretty(5)
```