### PR TITLE
Extrapolation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,37 @@
+# v0.8.7
+The 1D interpolation methods now support extrapolation using these methods:
+- `Constant`: Set all points outside the range of the interpolator to `extrapValue`.
+- `Edge`: Use the value of the left/right edge.
+- `Linear`: Uses linear extrapolation using the two points closest to the edge.
+- `Native` (default): Uses the native method of the interpolator to extrapolate. For Linear1D it will be a linear extrapolation, and for Cubic and Hermite splines it will be cubic extrapolation.
+- `Error`: Raises an `ValueError` if `x` is outside the range. 
+
+These are passed in as an argument to `eval` and `derivEval`:
+```nim
+let valEdge = interp.eval(x, Edge)
+let valConstant = interp.eval(x, Constant, NaN)
+```
+
+# v0.8.6
+- `levmarq` now accepts `yError`.
+- `paramUncertainties` allows you to calculate the uncertainties of fitted parameters.
+- `chi2` test added
+
+# v0.8.5
+Fix rbf bug.
+
+# v0.8.4
+With radial basis function interpolation, `numericalnim` finally gets an interpolation method which works on scattered data in arbitrary dimensions!
+
+Basic usage:
+```
+let interp = newRbf(points, values)
+let result = interp.eval(evalPoints)
+```
+
+# v0.8.1-v0.8.3
+CI-related bug fixes.
+
 # v0.8.0 - 09.05.2022
 ## Optimization has joined the chat
 Multi-variate optimization and differentiation has been introduced.

--- a/src/numericalnim/interpolate.nim
+++ b/src/numericalnim/interpolate.nim
@@ -290,7 +290,16 @@ proc missing(): Missing = discard
 
 proc eval*[T; U](interpolator: InterpolatorType[T], x: float, extrap: ExtrapolateKind = Native, extrapValue: U = missing()): T =
   ## Evaluates an interpolator.
-  # check for extrapolation
+  ## - `x`: The point to evaluate the interpolator at.
+  ## - `extrap`: The extrapolation method to use. Available options are:
+  ##  - `Constant`: Set all points outside the range of the interpolator to `extrapValue`.
+  ##  - `Edge`: Use the value of the left/right edge.
+  ##  - `Linear`: Uses linear extrapolation using the two points closest to the edge.
+  ##  - `Native` (default): Uses the native method of the interpolator to extrapolate. For Linear1D it will be a linear extrapolation, and for Cubic and Hermite splines it will be cubic extrapolation.
+  ##  - `Error`: Raises an `ValueError` if `x` is outside the range. 
+  ## - `extrapValue`: The extrapolation value to use when `extrap = Constant`.
+  ## 
+  ## > Beware: `Native` extrapolation for the cubic splines can very quickly diverge if the extrapolation is too far away from the interpolation points.
   when U is Missing:
     assert extrap != Constant, "When using `extrap = Constant`, a value `extrapValue` must be supplied!"
   else:
@@ -328,6 +337,16 @@ proc eval*[T; U](interpolator: InterpolatorType[T], x: float, extrap: Extrapolat
 
 proc derivEval*[T; U](interpolator: InterpolatorType[T], x: float, extrap: ExtrapolateKind = Native, extrapValue: U = missing()): T =
   ## Evaluates the derivative of an interpolator.
+  ## - `x`: The point to evaluate the interpolator at.
+  ## - `extrap`: The extrapolation method to use. Available options are:
+  ##  - `Constant`: Set all points outside the range of the interpolator to `extrapValue`.
+  ##  - `Edge`: Use the value of the left/right edge.
+  ##  - `Linear`: Uses linear extrapolation using the two points closest to the edge.
+  ##  - `Native` (default): Uses the native method of the interpolator to extrapolate. For Linear1D it will be a linear extrapolation, and for Cubic and Hermite splines it will be cubic extrapolation.
+  ##  - `Error`: Raises an `ValueError` if `x` is outside the range. 
+  ## - `extrapValue`: The extrapolation value to use when `extrap = Constant`.
+  ## 
+  ## > Beware: `Native` extrapolation for the cubic splines can very quickly diverge if the extrapolation is too far away from the interpolation points.
   when U is Missing:
     assert extrap != Constant, "When using `extrap = Constant`, a value `extrapValue` must be supplied!"
   else:

--- a/src/numericalnim/interpolate.nim
+++ b/src/numericalnim/interpolate.nim
@@ -17,6 +17,12 @@ export rbf
 ## - Hermite spline (recommended): cubic spline that works with many types of values. Accepts derivatives if available.
 ## - Cubic spline: cubic spline that only works with `float`s.
 ## - Linear spline: Linear spline that works with many types of values.
+## 
+## ### Extrapolation
+## Extrapolation is supported for all 1D interpolators by passing the type of extrapolation as an argument of `eval`.
+## The default is to use the interpolator's native method to extrapolate. This means that Linear does linear extrapolation,
+## while Hermite and Cubic performs cubic extrapolation. Other options are using a constant value, using the values of the edges,
+## linear extrapolation and raising an error if the x-value is outside the domain.
 
 runnableExamples:
   import numericalnim, std/[math, sequtils]
@@ -27,6 +33,8 @@ runnableExamples:
   let interp = newHermiteSpline(x, y)
 
   let val = interp.eval(0.314)
+
+  let valExtrapolate = interp.eval(1.1, Edge)
 
 ## ## 2D interpolation
 ## - Bicubic: Works on gridded data.

--- a/tests/test_interpolate.nim
+++ b/tests/test_interpolate.nim
@@ -186,6 +186,7 @@ test "linear1DSpline derivEval, seq input":
 
 let tOutside = @[-0.1, 10.1]
 let yOutside = tOutside.map(f)
+let dyOutside = tOutside.map(df)
 
 test "Extrapolate Constant":
     for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
@@ -218,6 +219,40 @@ test "Extrapolate Native (Hermit)":
     let res = hermiteSpline.eval(tOutside, Native)
     for (y1, y2) in zip(res, yOutside):
         check abs(y1 - y2) < 1.1e-2
+
+test "Extrapolate Deriv Constant":
+    for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
+        let res = interp.derivEval(tOutside, Constant, NaN)
+        for x in res:
+            check classify(x) == fcNan
+
+test "Extrapolate Deriv Edge":
+    for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
+        let res = interp.derivEval(tOutside, Edge)
+        check abs(res[0] - dy[0]) < 1e-2
+        check abs(res[1] - dy[^1]) < 4e-2
+
+test "Extrapolate Deriv Error":
+    for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
+        expect ValueError:
+            let res = interp.derivEval(tOutside, Error)
+
+test "Extrapolate Deriv Linear":
+    let exact = linear1DSpline.derivEval(tOutside, Native)
+    for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
+        let res = interp.derivEval(tOutside, ExtrapolateKind.Linear)
+        check abs(res[0] - exact[0]) < 1e-2
+        check abs(res[1] - exact[1]) < 5e-2
+
+test "Extrapolate Deriv Native (Cubic)":
+    let res = cubicSpline.derivEval(tOutside, Native)
+    check abs(res[0] - dyOutside[0]) < 1e-2
+    check abs(res[1] - dyOutside[^1]) < 1.05e-1
+
+test "Extrapolate Deriv Native (Hermit)":
+    let res = hermiteSpline.derivEval(tOutside, Native)
+    check abs(res[0] - dyOutside[0]) < 3e-2
+    check abs(res[1] - dyOutside[^1]) < 2e-1
 
 
 # 2D Interpolation

--- a/tests/test_interpolate.nim
+++ b/tests/test_interpolate.nim
@@ -191,7 +191,7 @@ test "Extrapolate Constant":
     for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
         let res = interp.eval(tOutside, Constant, NaN)
         for x in res:
-            check x.isNan()
+            check classify(x) == fcNan
 
 test "Extrapolate Edge":
     for interp in [linear1DSpline, cubicSpline, hermiteSpline]:

--- a/tests/test_interpolate.nim
+++ b/tests/test_interpolate.nim
@@ -184,6 +184,40 @@ test "linear1DSpline derivEval, seq input":
     for i, val in res:
         check isClose(val, cos(tTest[i]), 5e-2)
 
+let tOutside = @[-0.1, 10.1]
+let yOutside = tOutside.map(f)
+
+test "Extrapolate Constant":
+    for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
+        let res = interp.eval(tOutside, Constant, NaN)
+        for x in res:
+            check x.isNan()
+
+test "Extrapolate Edge":
+    for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
+        let res = interp.eval(tOutside, Edge)
+        check res == @[y[0], y[^1]]
+
+test "Extrapolate Error":
+    for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
+        expect ValueError:
+            let res = interp.eval(tOutside, Error)
+
+test "Extrapolate Linear":
+    let exact = linear1DSpline.eval(tOutside, Native)
+    for interp in [linear1DSpline, cubicSpline, hermiteSpline]:
+        let res = interp.eval(tOutside, ExtrapolateKind.Linear)
+        check res == exact
+
+test "Extrapolate Native (Cubic)":
+    let res = cubicSpline.eval(tOutside, Native)
+    for (y1, y2) in zip(res, yOutside):
+        check abs(y1 - y2) < 1e-2
+
+test "Extrapolate Native (Hermit)":
+    let res = hermiteSpline.eval(tOutside, Native)
+    for (y1, y2) in zip(res, yOutside):
+        check abs(y1 - y2) < 1.1e-2
 
 
 # 2D Interpolation


### PR DESCRIPTION
This PR implements extrapolation for the 1D interpolation methods. 
I chose to implement this functionality in `eval`. I still haven't implemented it for `derivEval`, and it would be a bit more cumbersome and inefficient as the values of the derivative isn't available and would have to be calculated. I'll continue tomorrow, but if anyone has any suggestions/improvements on this, please let me know. 

The `Missing` trick was from @Vindaar :pray: 

TODO:

- [x] `derivEval`
- [x] Update documentation
  - [x] Doc comment
  - [x] Example at the top

When this has been merged and tagged, I will also update the getting-started article on interpolation.  