### PR TITLE
avoid name collisions of `meshgrid`

### DIFF
--- a/src/numericalnim/rbf.nim
+++ b/src/numericalnim/rbf.nim
@@ -72,7 +72,7 @@ proc constructMeshedPatches*[T](grid: RbfGrid[T]): Tensor[float] =
   if grid.gridSize == 1:
     @[@[0.5].cycle(grid.gridDim)].toTensor
   else:
-    numericalnim.meshgrid(@[arraymancer.linspace(0 + grid.gridDelta / 2, 1 - grid.gridDelta / 2, grid.gridSize)].cycle(grid.gridDim))
+    utils.meshgrid(@[arraymancer.linspace(0 + grid.gridDelta / 2, 1 - grid.gridDelta / 2, grid.gridSize)].cycle(grid.gridDim))
 
 template dist2(p1, p2: Tensor[float]): float =
   var result = 0.0

--- a/src/numericalnim/rbf.nim
+++ b/src/numericalnim/rbf.nim
@@ -72,7 +72,7 @@ proc constructMeshedPatches*[T](grid: RbfGrid[T]): Tensor[float] =
   if grid.gridSize == 1:
     @[@[0.5].cycle(grid.gridDim)].toTensor
   else:
-    meshgrid(@[arraymancer.linspace(0 + grid.gridDelta / 2, 1 - grid.gridDelta / 2, grid.gridSize)].cycle(grid.gridDim))
+    numericalnim.meshgrid(@[arraymancer.linspace(0 + grid.gridDelta / 2, 1 - grid.gridDelta / 2, grid.gridSize)].cycle(grid.gridDim))
 
 template dist2(p1, p2: Tensor[float]): float =
   var result = 0.0

--- a/tests/test_interpolate.nim
+++ b/tests/test_interpolate.nim
@@ -481,12 +481,12 @@ test "Trilinear f = x*y*z T: Tensor[float]":
                check abs(spline.eval(i, j, k)[2] - 1) < 1e-16
 
 test "rbfBase f=x*y*z":
-    let pos = meshgrid(arraymancer.linspace(0.0, 1.0, 5), arraymancer.linspace(0.0, 1.0, 5), arraymancer.linspace(0.0, 1.0, 5))
+    let pos = numericalnim.meshgrid(arraymancer.linspace(0.0, 1.0, 5), arraymancer.linspace(0.0, 1.0, 5), arraymancer.linspace(0.0, 1.0, 5))
     let vals = pos[_, 0] *. pos[_, 1] *. pos[_, 2]
     let rbfObj = newRbfBase(pos, vals)
 
     # We want test points in the interior to avoid the edges
-    let xTest = meshgrid(arraymancer.linspace(0.1, 0.9, 10), arraymancer.linspace(0.1, 0.9, 10), arraymancer.linspace(0.1, 0.9, 10))
+    let xTest = numericalnim.meshgrid(arraymancer.linspace(0.1, 0.9, 10), arraymancer.linspace(0.1, 0.9, 10), arraymancer.linspace(0.1, 0.9, 10))
     let yTest = rbfObj.eval(xTest)
     let yCorrect = xTest[_, 0] *. xTest[_, 1] *. xTest[_, 2]
     for x in abs(yCorrect - yTest):
@@ -494,12 +494,12 @@ test "rbfBase f=x*y*z":
     check mean_squared_error(yTest, yCorrect) < 2e-4
     
 test "rbf f=x*y*z":
-    let pos = meshgrid(arraymancer.linspace(0.0, 1.0, 5), arraymancer.linspace(0.0, 1.0, 5), arraymancer.linspace(0.0, 1.0, 5))
+    let pos = numericalnim.meshgrid(arraymancer.linspace(0.0, 1.0, 5), arraymancer.linspace(0.0, 1.0, 5), arraymancer.linspace(0.0, 1.0, 5))
     let vals = pos[_, 0] *. pos[_, 1] *. pos[_, 2]
     let rbfObj = newRbf(pos, vals)
 
     # We want test points in the interior to avoid the edges
-    let xTest = meshgrid(arraymancer.linspace(0.1, 0.9, 10), arraymancer.linspace(0.1, 0.9, 10), arraymancer.linspace(0.1, 0.9, 10))
+    let xTest = numericalnim.meshgrid(arraymancer.linspace(0.1, 0.9, 10), arraymancer.linspace(0.1, 0.9, 10), arraymancer.linspace(0.1, 0.9, 10))
     let yTest = rbfObj.eval(xTest)
     let yCorrect = xTest[_, 0] *. xTest[_, 1] *. xTest[_, 2]
     for x in abs(yCorrect - yTest):

--- a/tests/test_utils.nim
+++ b/tests/test_utils.nim
@@ -88,7 +88,7 @@ test "meshgrid":
   let x = [0, 1].toTensor
   let y = [2, 3].toTensor
   let z = [4, 5].toTensor
-  let grid = meshgrid(x, y, z)
+  let grid = numericalnim.meshgrid(x, y, z)
   check grid == [[0, 2, 4], [1, 2, 4], [0, 3, 4], [1, 3, 4], [0, 2, 5], [1, 2, 5], [0, 3, 5], [1, 3, 5]].toTensor
 
 test "chi2 Tensor":


### PR DESCRIPTION
Arraymancer has added a `meshgrid` that conflicts with the `meshgrid` in numericalnim. Tests now use explicitly numericalnim's version.